### PR TITLE
🔀 : add install tuist action

### DIFF
--- a/.github/workflows/ios-cd.yml
+++ b/.github/workflows/ios-cd.yml
@@ -14,9 +14,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: install tuist
+        uses: curl -Ls https://install.tuist.io | bash
+
       - name: create .xcodeproj
         run: |
           TUIST_DEV=1 make generate
+
       - name: test
         run: |
           ls


### PR DESCRIPTION
## 개요
tuist 설치하는 스텝 추가

## 작업사항
ios cd yml에 tuist를 설치하는 스텝을 추가했습니다

## 변경로직


### 변경전
tuist no file or directory error

### 변경후
- name: install tuist
       uses: curl -Ls https://install.tuist.io | bash

## 사용방법


## 기타
